### PR TITLE
Add a settings to enable/disable a language

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,5 @@
     "search.exclude": {
         "out": true // set this to false to include "out" folder in search results
     },
-    "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
-    "editor.formatOnSave": false
+    "typescript.tsdk": "./node_modules/typescript/lib" // we want to use the TS server from our node_modules folder to control its version
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,11 @@
           "type": "boolean",
           "default": false,
           "description": "Suppress warnings when sorting fails."
+        },
+        "sortImports.languages": {
+          "type": "array",
+          "default": ["javascript", "typescript"],
+          "description": "Languages to sort on save."
         }
       }
     }

--- a/src/registration.ts
+++ b/src/registration.ts
@@ -25,6 +25,10 @@ export function getOnSaveSetting() {
   return workspace.getConfiguration("sortImports").get("onSave");
 }
 
+export function getLanguagesSetting(): string[] {
+  return workspace.getConfiguration("sortImports").get<string[]>("languages");
+}
+
 export function updateSaveRegistration() {
     if (getOnSaveSetting()) {
         registerWillSaveTextDocument();

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -11,6 +11,7 @@ import {
 } from 'vscode';
 import { dirname, extname } from 'path';
 import {
+    getLanguagesSetting,
     getOnSaveSetting,
     registerWillSaveTextDocument,
     unregisterWillSaveTextDocument,
@@ -20,8 +21,7 @@ import { getConfig } from 'import-sort-config';
 import importSort from 'import-sort';
 
 function sort(document: TextDocument): string {
-    const languageRegex = /^(java|type)script(react)*$/;
-    if (!document.languageId.match(languageRegex)) {
+    if (!getLanguagesSetting().some(l => document.languageId.includes(l)) ) {
         return;
     }
 


### PR DESCRIPTION
Ability to disable sort imports for a specific language.

I use TypeScript Hero (rbbit.typescript-hero) to sort my imports, I don't want to active the sort import extension for my .ts files.

:smile: 